### PR TITLE
Add cleanprofs data

### DIFF
--- a/MMM-Afvalwijzer.js
+++ b/MMM-Afvalwijzer.js
@@ -4,14 +4,15 @@ Module.register('MMM-Afvalwijzer', {
     defaults: {
         zipCode: "3607NR",
         houseNr: 1,
-        houseNrAddition: "",
+        extention: "",
         dateFormat: "dddd D MMMM",
         numberOfweeks: 2,
-        updateInterval: 4 * 60 * 60 * 1000 // Defaults to 4 hours
+        updateInterval: 4 * 60 * 60 * 1000, // Defaults to 4 hours
+        showCleanprofsData: false
     },
 
     start: function () {
-        this.sendSocketNotification('GET_TRASH_DATA', this.config.url);
+        this.sendSocketNotification('GET_TRASH_DATA', this.config.url)
     },
 
     socketNotificationReceived: function (notification, payload) {
@@ -37,7 +38,7 @@ Module.register('MMM-Afvalwijzer', {
 
     // Import additional CSS Styles
     getStyles: function () {
-        return ['MMM-Afvalwijzer.css']
+        return ['font-awesome.css', 'MMM-Afvalwijzer.css']
     },
 
     // Contact node_helper for the trash collection days
@@ -135,6 +136,17 @@ Module.register('MMM-Afvalwijzer', {
 
         return (svg);
     },
+    getCleanprofsIcon: function () {
+
+        let span = document.createElement("span")
+        span.classList.add("fa")
+        span.classList.add("fa-solid")
+        span.classList.add("fa-droplet")
+        span.style.color = "#2a70b8"
+        span.style.width = "24px"
+        span.style.height = "24px"
+        return (span)
+    },
     // Construct the DOM objects for this module
     getDom: function () {
         let wrapper = document.createElement("div");
@@ -144,7 +156,7 @@ Module.register('MMM-Afvalwijzer', {
             wrapper.className = "dimmed light small";
             return wrapper;
         }
-        console.log("TRASHDAYS", payloadReturn.ophaaldagen.data[0]);
+        console.log("TRASHDAYS", payloadReturn.ophaaldagen.data);
         for (i = 0; i < payloadReturn.ophaaldagen.data.length; i++) {
 
             let trashDay = payloadReturn.ophaaldagen.data[i];
@@ -177,6 +189,8 @@ Module.register('MMM-Afvalwijzer', {
 
                 let iconContainer = document.createElement("span");
                 iconContainer.classList.add("binday-icon-container");
+                if (trashDay.cleanprofs)
+                    iconContainer.appendChild(this.getCleanprofsIcon())
                 iconContainer.appendChild(this.getIconByTrashtype(trashDay.nameType));
 
                 pickupContainer.appendChild(iconContainer);

--- a/MMM-Afvalwijzer.js
+++ b/MMM-Afvalwijzer.js
@@ -90,7 +90,7 @@ Module.register('MMM-Afvalwijzer', {
                 break;
             case 'PLASTIC':
             case 'pmd':
-            case 'PLASTICPLUS':
+            case 'pbd':
                 color = "#e96c29";
                 break;
             case 'papier':

--- a/MMM-Afvalwijzer.js
+++ b/MMM-Afvalwijzer.js
@@ -6,28 +6,28 @@ Module.register('MMM-Afvalwijzer', {
         houseNr: 1,
         houseNrAddition: "",
         dateFormat: "dddd D MMMM",
-        numberOfweeks:2,
+        numberOfweeks: 2,
         updateInterval: 4 * 60 * 60 * 1000 // Defaults to 4 hours
     },
-  
+
     start: function () {
-      this.sendSocketNotification('GET_TRASH_DATA', this.config.url);
+        this.sendSocketNotification('GET_TRASH_DATA', this.config.url);
     },
-  
+
     socketNotificationReceived: function (notification, payload) {
-      if (notification === 'DATA_RECEIVED') {
-        this.processData(payload);
-        console.log("SUCCESS",payload);
-      } else if (notification === 'DATA_ERROR') {
-        console.error('Error:', payload);
-      }
+        if (notification === 'DATA_RECEIVED') {
+            this.processData(payload);
+            console.log("SUCCESS", payload);
+        } else if (notification === 'DATA_ERROR') {
+            console.error('Error:', payload);
+        }
     },
     getHeader: function () {
-                  return this.config.title;
-                 },
-  
+        return this.config.title;
+    },
+
     // Start the module
-    start: function() {
+    start: function () {
         this.trashDays = [];
         const payloadReturn = "";
         this.loaded = false;
@@ -36,32 +36,32 @@ Module.register('MMM-Afvalwijzer', {
     },
 
     // Import additional CSS Styles
-    getStyles: function() {
+    getStyles: function () {
         return ['MMM-Afvalwijzer.css']
     },
 
     // Contact node_helper for the trash collection days
-    getTrashCollectionDays: function() {
+    getTrashCollectionDays: function () {
         this.sendSocketNotification("GET_TRASH_DATA", {
             config: this.config
         });
     },
 
     // Schedule the update interval and update
-    scheduleUpdate: function(delay) {
+    scheduleUpdate: function (delay) {
         let nextLoad = this.config.updateInterval;
         if (typeof delay !== "undefined" && delay >= 0) {
             nextLoad = delay;
         }
 
         const self = this;
-        setInterval(function() {
+        setInterval(function () {
             self.getTrashCollectionDays();
         }, nextLoad);
     },
 
     // Handle node_helper response
-    socketNotificationReceived: function(notification, payload) {
+    socketNotificationReceived: function (notification, payload) {
         if (notification === "TRASH_DATA") {
             payloadReturn = payload;
             // Logging the JavaScript object
@@ -75,7 +75,7 @@ Module.register('MMM-Afvalwijzer', {
     },
     // Create icons
     getIconByTrashtype: function (trash_type) {
-        console.log("Trashtype",trash_type);
+        console.log("Trashtype", trash_type);
 
         let color = "#64656a";
 
@@ -92,6 +92,7 @@ Module.register('MMM-Afvalwijzer', {
             case 'PLASTICPLUS':
                 color = "#e96c29";
                 break;
+            case 'papier':
             case 'papier en karton':
                 color = "#2a70b8";
                 break;
@@ -134,8 +135,8 @@ Module.register('MMM-Afvalwijzer', {
 
         return (svg);
     },
-     // Construct the DOM objects for this module
-     getDom: function() {
+    // Construct the DOM objects for this module
+    getDom: function () {
         let wrapper = document.createElement("div");
 
         if (this.loaded === false) {
@@ -143,13 +144,13 @@ Module.register('MMM-Afvalwijzer', {
             wrapper.className = "dimmed light small";
             return wrapper;
         }
-          console.log("TRASHDAYS",payloadReturn.ophaaldagen.data[0]);
+        console.log("TRASHDAYS", payloadReturn.ophaaldagen.data[0]);
         for (i = 0; i < payloadReturn.ophaaldagen.data.length; i++) {
 
             let trashDay = payloadReturn.ophaaldagen.data[i];
 
             //console.log("Trashday",trashDay.date);
-         
+
             let pickupContainer = document.createElement("div");
             pickupContainer.classList.add("binday-container");
 
@@ -159,35 +160,34 @@ Module.register('MMM-Afvalwijzer', {
             moment.locale();
             let today = moment().startOf("day");
             let pickUpDate = moment(trashDay.date);
-            if(moment(pickUpDate)>moment(today)&&moment(pickUpDate)<(moment(today).add(this.config.numberOfweeks, "weeks")))
-           {
-            if (today.isSame(pickUpDate)) {
-                dateContainer.innerHTML = "Today";
-            } else if (moment(today).add(1, "days").isSame(pickUpDate)) {
-                dateContainer.innerHTML = "Tomorrow";
-            } else if (moment(today).add(7, "days").isAfter(pickUpDate)) {
-                dateContainer.innerHTML = this.capitalize(pickUpDate.format("dddd"));
-            } else {
-               dateContainer.innerHTML = this.capitalize(pickUpDate.format(this.config.dateFormat));
+            if (moment(pickUpDate) > moment(today) && moment(pickUpDate) < (moment(today).add(this.config.numberOfweeks, "weeks"))) {
+                if (today.isSame(pickUpDate)) {
+                    dateContainer.innerHTML = "Today";
+                } else if (moment(today).add(1, "days").isSame(pickUpDate)) {
+                    dateContainer.innerHTML = "Tomorrow";
+                } else if (moment(today).add(7, "days").isAfter(pickUpDate)) {
+                    dateContainer.innerHTML = this.capitalize(pickUpDate.format("dddd"));
+                } else {
+                    dateContainer.innerHTML = this.capitalize(pickUpDate.format(this.config.dateFormat));
+                }
+
+                dateContainer.innerHTML += ": " + this.capitalize(trashDay.type);
+
+                pickupContainer.appendChild(dateContainer);
+
+                let iconContainer = document.createElement("span");
+                iconContainer.classList.add("binday-icon-container");
+                iconContainer.appendChild(this.getIconByTrashtype(trashDay.nameType));
+
+                pickupContainer.appendChild(iconContainer);
+                wrapper.appendChild(pickupContainer);
             }
-           
-            dateContainer.innerHTML += ": " + this.capitalize(trashDay.type);
 
-            pickupContainer.appendChild(dateContainer);
-
-            let iconContainer = document.createElement("span");
-            iconContainer.classList.add("binday-icon-container");
-            iconContainer.appendChild(this.getIconByTrashtype(trashDay.nameType));
-
-            pickupContainer.appendChild(iconContainer);
-            wrapper.appendChild(pickupContainer);
         }
-            
-        }
-        
+
 
         return wrapper;
-        
+
     }
-  });
-  
+});
+

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Option|Default|Description
 `title`||Title of this module to show
 `apiKey`|{ContactMeForTheAPIKey}|The API key in order to retrieve the data: {ContactMeForTheAPIKey}
 `numberOfweeks`|2|Indicate the number of weeks you want to see the schedule in advance.
-`houseNumber`|`1`|House number of the address
-`postalCode`|`3607NR`|Postal code of the address
+`houseNumber`|1|House number of the address
+`postalCode`|3607NR|Postal code of the address
 `streetName`||Street name of the address
 `extention`||Housnumber addition of the address.
 `dateFormat`|dddd D MMMM|Date format 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,20 @@ Add the module to the modules array in the `config/config.js` file and insert yo
 			}
 		},
 ```
+## Configuration options
 
-If you do not have an extention then just leave it blank.
-`NumberOfWeeks` indicate the number of weeks you want to see the schedule in advance.
+Option|Default|Description
+------|------|-----------
+`title`||Title of this module to show
+`apiKey`|{ContactMeForTheAPIKey}|The API key in order to retrieve the data: {ContactMeForTheAPIKey}
+`numberOfweeks`|2|Indicate the number of weeks you want to see the schedule in advance.
+`houseNumber`|`1`|House number of the address
+`postalCode`|`3607NR`|Postal code of the address
+`streetName`||Street name of the address
+`extention`||Housnumber addition of the address.
+`dateFormat`|dddd D MMMM|Date format 
+`updateInterval`|4 * 60 * 60 * 1000|How often should the data be retrieved
+`showCleanprofsData`|`false`|Retrieve the dates that Clean Profs will clean the containers
 
 ## Sample screenshot
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,20 +1,30 @@
 const node_helper = require("node_helper");
 const Log = require("logger");
+const moment = require("moment")
 
 module.exports = node_helper.create({
 	socketNotificationReceived: async function (notification, payload) {
 		const self = this;
 
 		if (notification === "GET_TRASH_DATA") {
-			const afvalwijzer_url = 'https://api.mijnafvalwijzer.nl/webservices/appsinput/?apikey='+payload.config.apiKey+'&method=postcodecheck&postcode=' + payload.config.postalCode + '&street=' + payload.config.streetName + '&huisnummer=' + payload.config.houseNumber + '&toevoeging=' + payload.config.extention + '&app_name=afvalwijzer&platform=web&afvaldata=2022-10-19&langs=nl&&__cf_chl_tk=YKspnxe1mVfGgdRMHr_fA_eKMJX1NdWAiRw4lWv9AjE-1709554190-0.0.1.1-1941';
+			const afvalwijzer_url = 'https://api.mijnafvalwijzer.nl/webservices/appsinput/?apikey=' + payload.config.apiKey + '&method=postcodecheck&postcode=' + payload.config.postalCode + '&street=' + payload.config.streetName + '&huisnummer=' + payload.config.houseNumber + '&toevoeging=' + payload.config.extention + '&app_name=afvalwijzer&platform=web&afvaldata=2022-10-19&langs=nl&&__cf_chl_tk=YKspnxe1mVfGgdRMHr_fA_eKMJX1NdWAiRw4lWv9AjE-1709554190-0.0.1.1-1941';
+
 			let returnData = ""
 
 			try {
 				const response = await fetch(afvalwijzer_url);
 				const body = await response.json();
-				returnData = JSON.stringify(body.ophaaldagen);
-				if (body && body.ophaaldagen) {
-					returnData = body;
+
+				if (!body || !body.ophaaldagen) {
+					returnData = JSON.stringify(body.ophaaldagen)
+				}
+				else {
+					let result = body
+
+					if (payload.config.showCleanprofsData)
+						result = await self.appendCleanProfsData(payload, result)
+
+					returnData = result
 				}
 			} catch (error) {
 				Log.error("Error:", error);
@@ -22,4 +32,59 @@ module.exports = node_helper.create({
 			self.sendSocketNotification("TRASH_DATA", returnData);
 		}
 	},
+
+	appendCleanProfsData: async function (payload, afvalwijzerResult) {
+
+		const startdate = moment(new Date()).format('YYYY-MM-DD')
+		const enddate = moment(new Date(new Date().getTime() + (payload.config.numberOfweeks * 7 * 24 * 60 * 60 * 1000))).format('YYYY-MM-DD')
+		const cleanprofs_url = `https://cleanprofs.jmsdev.nl/api/get-plannings-address?zipcode=${payload.config.postalCode}&house_number=${payload.config.houseNumber}&start_date=${startdate}&end_date=${enddate}&code=crm`
+		console.log("cleanProfsUrl", cleanprofs_url)
+		//ophaaldagen looks like this:
+		// {
+		//   "ophaaldagen": {
+		//     "data": [
+		//       {
+		//         "date": "2022-10-19",
+		//         "nameType": "pmd",
+		//         "type": "pmd"
+		//       }
+		//     ]
+		//   }
+
+		//cleanprofs looks like this:
+		// [
+		// 	{ "product_name": "RST", "weekday": "vrijdag", "date": "30 aug.", "full_date": "2024-08-30" }
+		// ]
+
+		try {
+			const response = await fetch(cleanprofs_url)
+			const cleanprofsBody = await response.json()
+
+			if (cleanprofsBody) {
+				cleanprofsBody.forEach(cleanprofsDay => {
+					// update the ophaaldagen object with the cleanprofs data
+					// match on date and type of product
+
+					afvalwijzerResult.ophaaldagen.data
+						.filter(x => x.date === cleanprofsDay.full_date)
+						.filter(x => {
+							if ((x.nameType === "REST" || x.nameType === "restafval") &&
+								cleanprofsDay.product_name == "RST") {
+								return true
+							}
+							if ((x.nameType === "gft") &&
+								cleanprofsDay.product_name == "GFT") {
+								return true
+							}
+							return false
+						})
+						.forEach(x => x.cleanprofs = true)
+				})
+			}
+		} catch (error) {
+			Log.error("Error:", error);
+		}
+
+		return afvalwijzerResult
+	}
 });


### PR DESCRIPTION
@gertperdZA I use this module a lot. What I missed was the option to see if [Cleanprofs](https://www.cleanprofs.nl/ophaaldagen/) will stop by to clean my containers. Therefore I have added this in your module. In order to add the cleanprofs data the user can add 'showCleanprofsData: true' to their config. Only then the cleanprofs data is retrieved and added.

Would you be so kind to check this out and merge if you are ok with the change.

Example:
<img width="304" alt="image" src="https://github.com/user-attachments/assets/4feae1e8-aab8-4841-91ba-1ce59d2aaf0d">
